### PR TITLE
docs: add Examples/Documentation index

### DIFF
--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -1,0 +1,31 @@
+# Documentation Index
+
+- [](&)Documentation/API-Reference.md
+- [](&)Documentation/API.md
+- [](&)Documentation/API/UserAPI.md
+- [](&)Documentation/AppTemplatesAPI.md
+- [](&)Documentation/AppTemplatesGuide.md
+- [](&)Documentation/Architecture.md
+- [](&)Documentation/ArchitectureTemplatesAPI.md
+- [](&)Documentation/ArchitectureTemplatesGuide.md
+- [](&)Documentation/Best-Practices.md
+- [](&)Documentation/BestPracticesGuide.md
+- [](&)Documentation/ConfigurationAPI.md
+- [](&)Documentation/CustomizationAPI.md
+- [](&)Documentation/CustomizationGuide.md
+- [](&)Documentation/GenerationAPI.md
+- [](&)Documentation/Getting-Started.md
+- [](&)Documentation/GettingStarted.md
+- [](&)Documentation/Guides/ArchitectureGuide.md
+- [](&)Documentation/Guides/PerformanceGuide.md
+- [](&)Documentation/Guides/SecurityGuide.md
+- [](&)Documentation/Guides/TestingGuide.md
+- [](&)Documentation/Installation.md
+- [](&)Documentation/TemplateGuide.md
+- [](&)Documentation/TemplateManagerAPI.md
+- [](&)Documentation/TestingTemplatesAPI.md
+- [](&)Documentation/TestingTemplatesGuide.md
+- [](&)Documentation/Troubleshooting.md
+- [](&)Documentation/UIComponents.md
+- [](&)Documentation/UITemplatesAPI.md
+- [](&)Documentation/UITemplatesGuide.md

--- a/Examples/README.md
+++ b/Examples/README.md
@@ -1,24 +1,6 @@
-# 💡 Examples
+# Examples Index
 
-Welcome to our comprehensive examples collection! Here you'll find practical implementations and usage patterns for our framework.
-
-## 📱 Available Examples
-
-### Basic Example
-- **File**: `BasicExample.swift`
-- **Description**: Simple implementation showing fundamental usage
-- **Difficulty**: Beginner
-- **Use Case**: Quick prototyping and learning
-
-## 🚀 Getting Started
-
-1. **Choose an example** that matches your skill level
-2. **Copy the code** into your project
-3. **Customize** according to your needs
-4. **Build and run** to see it in action
-
-## 📚 Related Documentation
-
-- [Getting Started](Documentation/GettingStarted.md)
-- [API Reference](Documentation/API.md)
-- [Installation Guide](Documentation/Installation.md)
+- ``Examples/AdvancedExample.swift
+- ``Examples/BasicExample.swift
+- ``Examples/BasicExample/BasicExample.swift
+- ``Examples/QuickStartExample/QuickStartApp.swift


### PR DESCRIPTION
Adds repo-specific indices for Examples and Documentation folders. English-only; no placeholders.